### PR TITLE
Correct namespace in examples for the Yii2 component

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ return [
     ...
     'components'          => [
         'jasper' => [
-            'class' => 'chrmorandi\jasper',
+            'class' => chrmorandi\jasper\Jasper::className(),
             'redirect_output' => false, //optional
             'resource_directory' => false, //optional
             'locale' => pt_BR, //optional
@@ -139,7 +139,7 @@ return [
 ###Using
 
 ```php
-use chrmorandi\Jasper;
+use chrmorandi\jasper\Jasper;
 
 public function actionIndex()
 {


### PR DESCRIPTION
The component class is `chrmorandi\jasper\Jasper`, not `chrmorandi\jasper`.

Also, but this is more a matter of personal preference, using the `Object::className()` method for returning the FQCN for the component definition.